### PR TITLE
Avoid allocating a struct for each + and * operation. 15% FPS increase

### DIFF
--- a/ManagedDoom/src/Doom/Graphics/Column.cs
+++ b/ManagedDoom/src/Doom/Graphics/Column.cs
@@ -14,19 +14,16 @@
 //
 
 
-
-using System;
-
 namespace ManagedDoom
 {
     public sealed class Column
     {
         public const int Last = 0xFF;
 
-        private int topDelta;
-        private byte[] data;
-        private int offset;
-        private int length;
+        private readonly int topDelta;
+        private readonly byte[] data;
+        private readonly int offset;
+        private readonly int length;
 
         public Column(int topDelta, byte[] data, int offset, int length)
         {

--- a/ManagedDoom/src/Doom/Map/MapThing.cs
+++ b/ManagedDoom/src/Doom/Map/MapThing.cs
@@ -23,18 +23,18 @@ namespace ManagedDoom
     {
         private static readonly int dataSize = 10;
 
-        public static MapThing Empty = new MapThing(
+        public static readonly MapThing Empty = new MapThing(
             Fixed.Zero,
             Fixed.Zero,
             Angle.Ang0,
             0,
             0);
 
-        private Fixed x;
-        private Fixed y;
-        private Angle angle;
+        private readonly Fixed x;
+        private readonly Fixed y;
+        private readonly Angle angle;
         private int type;
-        private ThingFlags flags;
+        private readonly ThingFlags flags;
 
         public MapThing(
             Fixed x,

--- a/ManagedDoom/src/Doom/Math/Angle.cs
+++ b/ManagedDoom/src/Doom/Math/Angle.cs
@@ -20,7 +20,7 @@ using System.Runtime.CompilerServices;
 
 namespace ManagedDoom
 {
-    public struct Angle
+    public readonly struct Angle
     {
         public static readonly Angle Ang0 = new Angle(0x00000000);
         public static readonly Angle Ang45 = new Angle(0x20000000);
@@ -28,7 +28,7 @@ namespace ManagedDoom
         public static readonly Angle Ang180 = new Angle(0x80000000);
         public static readonly Angle Ang270 = new Angle(0xC0000000);
 
-        private uint data;
+        private readonly uint data;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Angle(uint data)

--- a/ManagedDoom/src/Doom/Math/Fixed.cs
+++ b/ManagedDoom/src/Doom/Math/Fixed.cs
@@ -113,7 +113,13 @@ namespace ManagedDoom
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Fixed operator *(Fixed a, Fixed b)
         {
-            return new Fixed((int)(((long)a.data * (long)b.data) >> FracBits));
+            return new Fixed(Multiply(a.Data, b));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int Multiply(int aData, Fixed b)
+        {
+            return (int)(((long)aData * b.Data) >> FracBits);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/ManagedDoom/src/Doom/Math/Fixed.cs
+++ b/ManagedDoom/src/Doom/Math/Fixed.cs
@@ -245,9 +245,15 @@ namespace ManagedDoom
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int ToIntFloor()
+        internal static int ToIntFloor(int data)
         {
             return data >> FracBits;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int ToIntFloor()
+        {
+            return ToIntFloor(data);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/ManagedDoom/src/Doom/Math/Fixed.cs
+++ b/ManagedDoom/src/Doom/Math/Fixed.cs
@@ -20,7 +20,7 @@ using System.Runtime.CompilerServices;
 
 namespace ManagedDoom
 {
-    public struct Fixed
+    public readonly struct Fixed
     {
         public const int FracBits = 16;
         public const int FracUnit = 1 << FracBits;
@@ -35,7 +35,7 @@ namespace ManagedDoom
         public static readonly Fixed OnePlusEpsilon = new Fixed(FracUnit + 1);
         public static readonly Fixed OneMinusEpsilon = new Fixed(FracUnit - 1);
 
-        private int data;
+        private readonly int data;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Fixed(int data)

--- a/ManagedDoom/src/Doom/Math/Geometry.cs
+++ b/ManagedDoom/src/Doom/Math/Geometry.cs
@@ -47,9 +47,7 @@ namespace ManagedDoom
 
             if (dy > dx)
             {
-                var temp = dx;
-                dx = dy;
-                dy = temp;
+                (dx, dy) = (dy, dx);
             }
 
             // The code below to avoid division by zero is based on Chocolate Doom's implementation.

--- a/ManagedDoom/src/Silk/SilkDoom.cs
+++ b/ManagedDoom/src/Silk/SilkDoom.cs
@@ -12,10 +12,10 @@ namespace ManagedDoom.Silk
 {
     public partial class SilkDoom : IDisposable
     {
-        private CommandLineArgs args;
+        private readonly CommandLineArgs args;
 
-        private Config config;
-        private GameContent content;
+        private readonly Config config;
+        private readonly GameContent content;
 
         private IWindow window;
 

--- a/ManagedDoom/src/Silk/SilkVideo.cs
+++ b/ManagedDoom/src/Silk/SilkVideo.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Drawing;
 using System.Numerics;
 using System.Runtime.ExceptionServices;
 using Silk.NET.OpenGL;
@@ -11,14 +10,14 @@ namespace ManagedDoom.Silk
 {
     public sealed class SilkVideo : IVideo, IDisposable
     {
-        private Renderer renderer;
+        private readonly Renderer renderer;
 
         private GraphicsDevice device;
 
-        private int textureWidth;
-        private int textureHeight;
+        private readonly int textureWidth;
+        private readonly int textureHeight;
 
-        private byte[] textureData;
+        private readonly byte[] textureData;
         private Texture2D texture;
 
         private TextureBatcher batcher;

--- a/ManagedDoom/src/Video/DrawScreen.cs
+++ b/ManagedDoom/src/Video/DrawScreen.cs
@@ -112,6 +112,7 @@ namespace ManagedDoom.Video
             var step = Fixed.One / scale;
 
             Fixed initialFrac = step - Fixed.Epsilon;
+            int stepData = step.Data;
             foreach (var column in source)
             {
                 var exTopDelta = scale * column.TopDelta;
@@ -139,11 +140,12 @@ namespace ManagedDoom.Video
                     drawLength -= exceed;
                 }
 
+                int fracData = frac.Data;
                 for (; i < drawLength; i++)
                 {
-                    data[p] = column.Data[sourceIndex + frac.ToIntFloor()];
+                    data[p] = column.Data[sourceIndex + Fixed.ToIntFloor(fracData)];
                     p++;
-                    frac += step;
+                    fracData += stepData;
                 }
             }
         }

--- a/ManagedDoom/src/Video/DrawScreen.cs
+++ b/ManagedDoom/src/Video/DrawScreen.cs
@@ -22,11 +22,11 @@ namespace ManagedDoom.Video
 {
     public sealed class DrawScreen
     {
-        private int width;
-        private int height;
-        private byte[] data;
+        private readonly int width;
+        private readonly int height;
+        private readonly byte[] data;
 
-        private Patch[] chars;
+        private readonly Patch[] chars;
 
         public DrawScreen(Wad wad, int width, int height)
         {
@@ -111,6 +111,7 @@ namespace ManagedDoom.Video
         {
             var step = Fixed.One / scale;
 
+            Fixed initialFrac = step - Fixed.Epsilon;
             foreach (var column in source)
             {
                 var exTopDelta = scale * column.TopDelta;
@@ -122,7 +123,7 @@ namespace ManagedDoom.Video
 
                 var i = 0;
                 var p = height * x + drawY;
-                var frac = Fixed.One / scale - Fixed.Epsilon;
+                var frac = initialFrac;
 
                 if (drawY < 0)
                 {

--- a/ManagedDoom/src/Video/Renderer.cs
+++ b/ManagedDoom/src/Video/Renderer.cs
@@ -22,7 +22,7 @@ namespace ManagedDoom.Video
 {
     public sealed class Renderer
     {
-        private static double[] gammaCorrectionParameters = new double[]
+        private static readonly double[] gammaCorrectionParameters = new double[]
         {
             1.00,
             0.95,
@@ -37,26 +37,26 @@ namespace ManagedDoom.Video
             0.50
         };
 
-        private Config config;
+        private readonly Config config;
 
-        private Palette palette;
+        private readonly Palette palette;
 
-        private DrawScreen screen;
+        private readonly DrawScreen screen;
 
-        private MenuRenderer menu;
-        private ThreeDRenderer threeD;
-        private StatusBarRenderer statusBar;
-        private IntermissionRenderer intermission;
-        private OpeningSequenceRenderer openingSequence;
-        private AutoMapRenderer autoMap;
-        private FinaleRenderer finale;
+        private readonly MenuRenderer menu;
+        private readonly ThreeDRenderer threeD;
+        private readonly StatusBarRenderer statusBar;
+        private readonly IntermissionRenderer intermission;
+        private readonly OpeningSequenceRenderer openingSequence;
+        private readonly AutoMapRenderer autoMap;
+        private readonly FinaleRenderer finale;
 
-        private Patch pause;
+        private readonly Patch pause;
 
-        private int wipeBandWidth;
-        private int wipeBandCount;
-        private int wipeHeight;
-        private byte[] wipeBuffer;
+        private readonly int wipeBandWidth;
+        private readonly int wipeBandCount;
+        private readonly int wipeHeight;
+        private readonly byte[] wipeBuffer;
 
         public Renderer(Config config, GameContent content)
         {

--- a/ManagedDoom/src/Video/ThreeDRenderer.cs
+++ b/ManagedDoom/src/Video/ThreeDRenderer.cs
@@ -2271,12 +2271,14 @@ namespace ManagedDoom.Video
             // This is as fast as it gets.
             var source = column.Data;
             var offset = column.Offset;
+            int fracData = frac.Data;
+            int fracStepData = fracStep.Data;
             for (var pos = pos1; pos <= pos2; pos++)
             {
                 // Re-map color indices from wall texture column
                 // using a lighting/special effects LUT.
-                screenData[pos] = map[source[offset + ((frac.Data >> Fixed.FracBits) & 127)]];
-                frac += fracStep;
+                screenData[pos] = map[source[offset + ((fracData >> Fixed.FracBits) & 127)]];
+                fracData += fracStepData;
             }
         }
 

--- a/ManagedDoom/src/Video/ThreeDRenderer.cs
+++ b/ManagedDoom/src/Video/ThreeDRenderer.cs
@@ -234,8 +234,8 @@ namespace ManagedDoom.Video
         private int floorPrevY2;
         private int[] floorXFracData;
         private int[] floorYFracData;
-        private Fixed[] floorXStep;
-        private Fixed[] floorYStep;
+        private int[] floorXStepData;
+        private int[] floorYStepData;
         private byte[][] floorLights;
 
         private void InitPlaneRendering()
@@ -249,8 +249,8 @@ namespace ManagedDoom.Video
             ceilingLights = new byte[screenHeight][];
             floorXFracData = new int[screenHeight];
             floorYFracData = new int[screenHeight];
-            floorXStep = new Fixed[screenHeight];
-            floorYStep = new Fixed[screenHeight];
+            floorXStepData = new int[screenHeight];
+            floorYStepData = new int[screenHeight];
             floorLights = new byte[screenHeight][];
         }
 
@@ -2143,6 +2143,7 @@ namespace ManagedDoom.Video
             }
 
             var height = Fixed.Abs(floorHeight - viewZ);
+            int heightData = height.Data;
 
             var flatData = flat.Data;
 
@@ -2155,18 +2156,18 @@ namespace ManagedDoom.Video
 
                 for (var y = y1; y < p1; y++)
                 {
-                    var distance = height * planeYSlope[y];
-                    floorXStep[y] = distance * planeBaseXScale;
-                    floorYStep[y] = distance * planeBaseYScale;
+                    int distanceData = Fixed.Multiply(heightData, planeYSlope[y]);
+                    floorXStepData[y] = Fixed.Multiply(distanceData, planeBaseXScale);
+                    floorYStepData[y] = Fixed.Multiply(distanceData, planeBaseYScale);
 
-                    var length = distance * planeDistScale[x];
+                    int length = Fixed.Multiply(distanceData, planeDistScale[x]);
                     var angle = viewAngle + xToAngle[x];
                     var xFrac = viewX + Trig.Cos(angle) * length;
                     var yFrac = -viewY - Trig.Sin(angle) * length;
                     floorXFracData[y] = xFrac.Data;
                     floorYFracData[y] = yFrac.Data;
 
-                    var colorMap = planeLights[Math.Min((uint)(distance.Data >> zLightShift), maxZLight - 1)];
+                    byte[] colorMap = planeLights[Math.Min((uint)(distanceData >> zLightShift), maxZLight - 1)];
                     floorLights[y] = colorMap;
 
                     var spot = ((yFrac.Data >> (16 - 6)) & (63 * 64)) + ((xFrac.Data >> 16) & 63);
@@ -2176,8 +2177,8 @@ namespace ManagedDoom.Video
 
                 for (var y = p1; y <= p2; y++)
                 {
-                    int xFracData = floorXFracData[y] + floorXStep[y].Data;
-                    int yFracData = floorYFracData[y] + floorYStep[y].Data;
+                    int xFracData = floorXFracData[y] + floorXStepData[y];
+                    int yFracData = floorYFracData[y] + floorYStepData[y];
 
                     var spot = ((yFracData >> (16 - 6)) & (63 * 64)) + ((xFracData >> 16) & 63);
                     screenData[pos] = floorLights[y][flatData[spot]];
@@ -2189,18 +2190,18 @@ namespace ManagedDoom.Video
 
                 for (var y = p2 + 1; y <= y2; y++)
                 {
-                    var distance = height * planeYSlope[y];
-                    floorXStep[y] = distance * planeBaseXScale;
-                    floorYStep[y] = distance * planeBaseYScale;
+                    int distanceData = Fixed.Multiply(heightData, planeYSlope[y]);
+                    floorXStepData[y] = Fixed.Multiply(distanceData, planeBaseXScale);
+                    floorYStepData[y] = Fixed.Multiply(distanceData, planeBaseYScale);
 
-                    var length = distance * planeDistScale[x];
+                    int length = Fixed.Multiply(distanceData, planeDistScale[x]);
                     var angle = viewAngle + xToAngle[x];
                     var xFrac = viewX + Trig.Cos(angle) * length;
                     var yFrac = -viewY - Trig.Sin(angle) * length;
                     floorXFracData[y] = xFrac.Data;
                     floorYFracData[y] = yFrac.Data;
 
-                    var colorMap = planeLights[Math.Min((uint)(distance.Data >> zLightShift), maxZLight - 1)];
+                    byte[] colorMap = planeLights[Math.Min((uint)(distanceData >> zLightShift), maxZLight - 1)];
                     floorLights[y] = colorMap;
 
                     var spot = ((yFrac.Data >> (16 - 6)) & (63 * 64)) + ((xFrac.Data >> 16) & 63);
@@ -2214,18 +2215,18 @@ namespace ManagedDoom.Video
 
                 for (var y = y1; y <= y2; y++)
                 {
-                    var distance = height * planeYSlope[y];
-                    floorXStep[y] = distance * planeBaseXScale;
-                    floorYStep[y] = distance * planeBaseYScale;
+                    int distanceData = Fixed.Multiply(heightData, planeYSlope[y]);
+                    floorXStepData[y] = Fixed.Multiply(distanceData, planeBaseXScale);
+                    floorXStepData[y] = Fixed.Multiply(distanceData, planeBaseYScale);
 
-                    var length = distance * planeDistScale[x];
+                    int length = Fixed.Multiply(distanceData, planeDistScale[x]);
                     var angle = viewAngle + xToAngle[x];
                     var xFrac = viewX + Trig.Cos(angle) * length;
                     var yFrac = -viewY - Trig.Sin(angle) * length;
                     floorXFracData[y] = xFrac.Data;
                     floorYFracData[y] = yFrac.Data;
 
-                    var colorMap = planeLights[Math.Min((uint)(distance.Data >> zLightShift), maxZLight - 1)];
+                    byte[] colorMap = planeLights[Math.Min((uint)(distanceData >> zLightShift), maxZLight - 1)];
                     floorLights[y] = colorMap;
 
                     var spot = ((yFrac.Data >> (16 - 6)) & (63 * 64)) + ((xFrac.Data >> 16) & 63);

--- a/ManagedDoom/src/Video/ThreeDRenderer.cs
+++ b/ManagedDoom/src/Video/ThreeDRenderer.cs
@@ -222,8 +222,8 @@ namespace ManagedDoom.Video
         private int ceilingPrevX;
         private int ceilingPrevY1;
         private int ceilingPrevY2;
-        private Fixed[] ceilingXFrac;
-        private Fixed[] ceilingYFrac;
+        private int[] ceilingXFracData;
+        private int[] ceilingYFracData;
         private Fixed[] ceilingXStep;
         private Fixed[] ceilingYStep;
         private byte[][] ceilingLights;
@@ -242,8 +242,8 @@ namespace ManagedDoom.Video
         {
             planeYSlope = new Fixed[screenHeight];
             planeDistScale = new Fixed[screenWidth];
-            ceilingXFrac = new Fixed[screenHeight];
-            ceilingYFrac = new Fixed[screenHeight];
+            ceilingXFracData = new int[screenHeight];
+            ceilingYFracData = new int[screenHeight];
             ceilingXStep = new Fixed[screenHeight];
             ceilingYStep = new Fixed[screenHeight];
             ceilingLights = new byte[screenHeight][];
@@ -2045,8 +2045,8 @@ namespace ManagedDoom.Video
                     var angle = viewAngle + xToAngle[x];
                     var xFrac = viewX + Trig.Cos(angle) * length;
                     var yFrac = -viewY - Trig.Sin(angle) * length;
-                    ceilingXFrac[y] = xFrac;
-                    ceilingYFrac[y] = yFrac;
+                    ceilingXFracData[y] = xFrac.Data;
+                    ceilingYFracData[y] = yFrac.Data;
 
                     var colorMap = planeLights[Math.Min((uint)(distance.Data >> zLightShift), maxZLight - 1)];
                     ceilingLights[y] = colorMap;
@@ -2058,15 +2058,15 @@ namespace ManagedDoom.Video
 
                 for (var y = p1; y <= p2; y++)
                 {
-                    var xFrac = ceilingXFrac[y] + ceilingXStep[y];
-                    var yFrac = ceilingYFrac[y] + ceilingYStep[y];
+                    int xFracData = ceilingXFracData[y] + ceilingXStep[y].Data;
+                    int yFracData = ceilingYFracData[y] + ceilingYStep[y].Data;
 
-                    var spot = ((yFrac.Data >> (16 - 6)) & (63 * 64)) + ((xFrac.Data >> 16) & 63);
+                    var spot = ((yFracData >> (16 - 6)) & (63 * 64)) + ((xFracData >> 16) & 63);
                     screenData[pos] = ceilingLights[y][flatData[spot]];
                     pos++;
 
-                    ceilingXFrac[y] = xFrac;
-                    ceilingYFrac[y] = yFrac;
+                    ceilingXFracData[y] = xFracData;
+                    ceilingYFracData[y] = yFracData;
                 }
 
                 for (var y = p2 + 1; y <= y2; y++)
@@ -2079,8 +2079,8 @@ namespace ManagedDoom.Video
                     var angle = viewAngle + xToAngle[x];
                     var xFrac = viewX + Trig.Cos(angle) * length;
                     var yFrac = -viewY - Trig.Sin(angle) * length;
-                    ceilingXFrac[y] = xFrac;
-                    ceilingYFrac[y] = yFrac;
+                    ceilingXFracData[y] = xFrac.Data;
+                    ceilingYFracData[y] = yFrac.Data;
 
                     var colorMap = planeLights[Math.Min((uint)(distance.Data >> zLightShift), maxZLight - 1)];
                     ceilingLights[y] = colorMap;
@@ -2104,8 +2104,8 @@ namespace ManagedDoom.Video
                     var angle = viewAngle + xToAngle[x];
                     var xFrac = viewX + Trig.Cos(angle) * length;
                     var yFrac = -viewY - Trig.Sin(angle) * length;
-                    ceilingXFrac[y] = xFrac;
-                    ceilingYFrac[y] = yFrac;
+                    ceilingXFracData[y] = xFrac.Data;
+                    ceilingYFracData[y] = yFrac.Data;
 
                     var colorMap = planeLights[Math.Min((uint)(distance.Data >> zLightShift), maxZLight - 1)];
                     ceilingLights[y] = colorMap;

--- a/ManagedDoom/src/Video/ThreeDRenderer.cs
+++ b/ManagedDoom/src/Video/ThreeDRenderer.cs
@@ -232,8 +232,8 @@ namespace ManagedDoom.Video
         private int floorPrevX;
         private int floorPrevY1;
         private int floorPrevY2;
-        private Fixed[] floorXFrac;
-        private Fixed[] floorYFrac;
+        private int[] floorXFracData;
+        private int[] floorYFracData;
         private Fixed[] floorXStep;
         private Fixed[] floorYStep;
         private byte[][] floorLights;
@@ -247,8 +247,8 @@ namespace ManagedDoom.Video
             ceilingXStep = new Fixed[screenHeight];
             ceilingYStep = new Fixed[screenHeight];
             ceilingLights = new byte[screenHeight][];
-            floorXFrac = new Fixed[screenHeight];
-            floorYFrac = new Fixed[screenHeight];
+            floorXFracData = new int[screenHeight];
+            floorYFracData = new int[screenHeight];
             floorXStep = new Fixed[screenHeight];
             floorYStep = new Fixed[screenHeight];
             floorLights = new byte[screenHeight][];
@@ -2163,8 +2163,8 @@ namespace ManagedDoom.Video
                     var angle = viewAngle + xToAngle[x];
                     var xFrac = viewX + Trig.Cos(angle) * length;
                     var yFrac = -viewY - Trig.Sin(angle) * length;
-                    floorXFrac[y] = xFrac;
-                    floorYFrac[y] = yFrac;
+                    floorXFracData[y] = xFrac.Data;
+                    floorYFracData[y] = yFrac.Data;
 
                     var colorMap = planeLights[Math.Min((uint)(distance.Data >> zLightShift), maxZLight - 1)];
                     floorLights[y] = colorMap;
@@ -2176,15 +2176,15 @@ namespace ManagedDoom.Video
 
                 for (var y = p1; y <= p2; y++)
                 {
-                    var xFrac = floorXFrac[y] + floorXStep[y];
-                    var yFrac = floorYFrac[y] + floorYStep[y];
+                    int xFracData = floorXFracData[y] + floorXStep[y].Data;
+                    int yFracData = floorYFracData[y] + floorYStep[y].Data;
 
-                    var spot = ((yFrac.Data >> (16 - 6)) & (63 * 64)) + ((xFrac.Data >> 16) & 63);
+                    var spot = ((yFracData >> (16 - 6)) & (63 * 64)) + ((xFracData >> 16) & 63);
                     screenData[pos] = floorLights[y][flatData[spot]];
                     pos++;
 
-                    floorXFrac[y] = xFrac;
-                    floorYFrac[y] = yFrac;
+                    floorXFracData[y] = xFracData;
+                    floorYFracData[y] = yFracData;
                 }
 
                 for (var y = p2 + 1; y <= y2; y++)
@@ -2197,8 +2197,8 @@ namespace ManagedDoom.Video
                     var angle = viewAngle + xToAngle[x];
                     var xFrac = viewX + Trig.Cos(angle) * length;
                     var yFrac = -viewY - Trig.Sin(angle) * length;
-                    floorXFrac[y] = xFrac;
-                    floorYFrac[y] = yFrac;
+                    floorXFracData[y] = xFrac.Data;
+                    floorYFracData[y] = yFrac.Data;
 
                     var colorMap = planeLights[Math.Min((uint)(distance.Data >> zLightShift), maxZLight - 1)];
                     floorLights[y] = colorMap;
@@ -2222,8 +2222,8 @@ namespace ManagedDoom.Video
                     var angle = viewAngle + xToAngle[x];
                     var xFrac = viewX + Trig.Cos(angle) * length;
                     var yFrac = -viewY - Trig.Sin(angle) * length;
-                    floorXFrac[y] = xFrac;
-                    floorYFrac[y] = yFrac;
+                    floorXFracData[y] = xFrac.Data;
+                    floorYFracData[y] = yFrac.Data;
 
                     var colorMap = planeLights[Math.Min((uint)(distance.Data >> zLightShift), maxZLight - 1)];
                     floorLights[y] = colorMap;


### PR DESCRIPTION
- Avoid allocating a struct for each + and * operation. 15% FPS increase in timedemo demo3.
- Hoisting variable
- readonly modifiers.
Tested with  `"commandLineArgs": "-nosound -timedemo demo3"`