### PR TITLE
chore(deps): nuget package updates applied

### DIFF
--- a/ManagedDoom/ManagedDoom.csproj
+++ b/ManagedDoom/ManagedDoom.csproj
@@ -20,8 +20,8 @@
   <ItemGroup>
     <PackageReference Include="DrippyAL" Version="2.1.3" />
     <PackageReference Include="MeltySynth" Version="2.4.1" />
-    <PackageReference Include="Silk.NET.Input.Glfw" Version="2.21.0" />
-    <PackageReference Include="Silk.NET.Windowing.Glfw" Version="2.21.0" />
+    <PackageReference Include="Silk.NET.Input.Glfw" Version="2.22.0" />
+    <PackageReference Include="Silk.NET.Windowing.Glfw" Version="2.22.0" />
     <PackageReference Include="TrippyGL" Version="1.2.1" />
   </ItemGroup>
 

--- a/ManagedDoomTest/ManagedDoomTest.csproj
+++ b/ManagedDoomTest/ManagedDoomTest.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.5.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.5.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.3" />
     <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
changes:
- bumped `Silk.NET.Input.Glfw` from `2.21.0` to `2.22.0`
- bumped `Silk.NET.Windowing.Glfw` from `2.21.0` to `2.22.0`
- bumped `Microsoft.NET.Test.Sdk` from `17.11.1` to `17.12.0`
- bumped `MSTest.TestAdapter` from `3.5.2` to `3.6.3`
- bumped `MSTest.TestFramework` from `3.5.2` to `3.6.3`